### PR TITLE
Remove the correct view controller when replacing the viewcontroller

### DIFF
--- a/Source/SlideMenuController.swift
+++ b/Source/SlideMenuController.swift
@@ -542,7 +542,7 @@ class SlideMenuController: UIViewController, UIGestureRecognizerDelegate {
     
     func changeMainViewController(mainViewController: UIViewController,  close: Bool) {
         
-        removeViewController(mainViewController)
+        removeViewController(self.mainViewController)
         self.mainViewController = mainViewController
         setUpViewController(mainContainerView, targetViewController: mainViewController)
         if (close) {
@@ -553,7 +553,7 @@ class SlideMenuController: UIViewController, UIGestureRecognizerDelegate {
     
     func changeLeftViewController(leftViewController: UIViewController, closeLeft:Bool) {
         
-        removeViewController(leftViewController)
+        removeViewController(self.leftViewController)
         self.leftViewController = leftViewController
         setUpViewController(leftContainerView, targetViewController: leftViewController)
         if closeLeft {
@@ -562,7 +562,7 @@ class SlideMenuController: UIViewController, UIGestureRecognizerDelegate {
     }
     
     func changeRightViewController(rightViewController: UIViewController, closeRight:Bool) {
-        removeViewController(rightViewController)
+        removeViewController(self.rightViewController)
         self.rightViewController = rightViewController;
         setUpViewController(rightContainerView, targetViewController: rightViewController)
         if closeRight {


### PR DESCRIPTION
When changing the main view controller we noticed that the old one didn't get removed from the view.

This pull request fixes this issue.