### PR TITLE
Trigger `viewWillAppear` on mainViewController when SlideMenuController appears on screen

### DIFF
--- a/Source/SlideMenuController.swift
+++ b/Source/SlideMenuController.swift
@@ -154,6 +154,11 @@ class SlideMenuController: UIViewController, UIGestureRecognizerDelegate {
         super.viewDidLoad()
         edgesForExtendedLayout = UIRectEdge.None
     }
+
+    override func viewWillAppear(animated: Bool) {
+        super.viewWillAppear(animated)
+        self.mainViewController?.viewWillAppear(animated)
+    }
     
     override func viewWillLayoutSubviews() {
         // topLayoutGuideの値が確定するこのタイミングで各種ViewControllerをセットする


### PR DESCRIPTION
`viewWillAppear` isn't called on the initial `mainViewController`, so trigger it when `SlideMenuController`'s view will appear.

When the main view controller is replaced while `SlideMenuController` is on screen, all callbacks work as expected.