### PR TITLE
FIX: Right View subView(s) goes off the View bounds

### DIFF
--- a/Source/SlideMenuController.swift
+++ b/Source/SlideMenuController.swift
@@ -54,7 +54,11 @@ public class SlideMenuController: UIViewController, UIGestureRecognizerDelegate 
     public var leftViewController: UIViewController?
     public var leftPanGesture: UIPanGestureRecognizer?
     public var leftTapGesture: UITapGestureRecognizer?
-    public var rightViewController: UIViewController?
+    public var rightViewController: UIViewController? {
+    	didSet {
+            rightViewController?.view.clipsToBounds = true
+        }
+    }
     public var rightPanGesture: UIPanGestureRecognizer?
     public var rightTapGesture: UITapGestureRecognizer?
     


### PR DESCRIPTION
One of the rightViewController subviews goes off the bounds

I faced it in more than one case 
One of them is when you have and imageview that it's content Mode is set to 'Aspect fill' The image may goes off the screen .
(http://bit.ly/1XNRCP2)