### PR TITLE
UI Freeze after move application to background state

### DIFF
--- a/Source/SlideMenuController.swift
+++ b/Source/SlideMenuController.swift
@@ -316,7 +316,7 @@ public class SlideMenuController: UIViewController, UIGestureRecognizerDelegate 
                 leftContainerView.frame = applyLeftTranslation(translation, toFrame: LeftPanState.frameAtStartOfPan)
                 applyLeftOpacity()
                 applyLeftContentViewScale()
-            case UIGestureRecognizerState.Ended:
+            case UIGestureRecognizerState.Ended, UIGestureRecognizerState.Cancelled:
                 
                 let velocity:CGPoint = panGesture.velocityInView(panGesture.view)
                 let panInfo: PanInfo = panLeftResultInfoForVelocity(velocity)
@@ -379,7 +379,7 @@ public class SlideMenuController: UIViewController, UIGestureRecognizerDelegate 
             applyRightOpacity()
             applyRightContentViewScale()
             
-        case UIGestureRecognizerState.Ended:
+        case UIGestureRecognizerState.Ended, UIGestureRecognizerState.Cancelled:
             
             let velocity: CGPoint = panGesture.velocityInView(panGesture.view)
             let panInfo: PanInfo = panRightResultInfoForVelocity(velocity)

--- a/Source/SlideMenuController.swift
+++ b/Source/SlideMenuController.swift
@@ -338,7 +338,7 @@ public class SlideMenuController: UIViewController, UIGestureRecognizerDelegate 
                     track(.FlickClose)
 
                 }
-        default:
+        case UIGestureRecognizerState.Failed, UIGestureRecognizerState.Possible:
             break
         }
         
@@ -396,7 +396,7 @@ public class SlideMenuController: UIViewController, UIGestureRecognizerDelegate 
                 closeRightWithVelocity(panInfo.velocity)
                 setCloseWindowLebel()
             }
-        default:
+        case UIGestureRecognizerState.Failed, UIGestureRecognizerState.Possible:
             break
         }
     }


### PR DESCRIPTION
If while sliding menu application move to background (for example, because phone receive incoming call), then after returning to foreground state user interface freeze. (isLeftOpen() or isRightOpen() methods return that the menu is opened fully)