### PR TITLE
Forwards the shouldAutorotate() request to the mainController.

### DIFF
--- a/Source/SlideMenuController.swift
+++ b/Source/SlideMenuController.swift
@@ -193,6 +193,10 @@ public class SlideMenuController: UIViewController, UIGestureRecognizerDelegate 
         return UIInterfaceOrientationMask.All
     }
     
+    public override func shouldAutorotate() -> Bool {
+        return mainViewController?.shouldAutorotate() ?? false
+    }
+        
     public override func viewWillLayoutSubviews() {
         // topLayoutGuideの値が確定するこのタイミングで各種ViewControllerをセットする
         setUpViewController(mainContainerView, targetViewController: mainViewController)


### PR DESCRIPTION
Right now, the SlideMenuController defaults shouldAutorotate to true.
Instead, forwards the request to the mainController which can override the default if needed.
