### PR TITLE
Fix - status bar remains hidden occationally

### DIFF
--- a/Source/SlideMenuController.swift
+++ b/Source/SlideMenuController.swift
@@ -378,10 +378,6 @@ public class SlideMenuController: UIViewController, UIGestureRecognizerDelegate 
                 applyLeftOpacity()
                 applyLeftContentViewScale()
             case UIGestureRecognizerState.Ended, UIGestureRecognizerState.Cancelled:
-                if LeftPanState.lastState != .Changed {
-                    return
-                }
-                
                 let velocity:CGPoint = panGesture.velocityInView(panGesture.view)
                 let panInfo: PanInfo = panLeftResultInfoForVelocity(velocity)
                 
@@ -459,10 +455,6 @@ public class SlideMenuController: UIViewController, UIGestureRecognizerDelegate 
             applyRightContentViewScale()
             
         case UIGestureRecognizerState.Ended, UIGestureRecognizerState.Cancelled:
-            if RightPanState.lastState != .Changed {
-                return
-            }
-            
             let velocity: CGPoint = panGesture.velocityInView(panGesture.view)
             let panInfo: PanInfo = panRightResultInfoForVelocity(velocity)
             


### PR DESCRIPTION
https://github.com/dekatotoro/SlideMenuControllerSwift/blob/master/Source/SlideMenuController.swift#L463

```
case UIGestureRecognizerState.Ended, UIGestureRecognizerState.Cancelled:
            if RightPanState.lastState != .Changed {
                return
            }
```

When this condition occurs, it just returns without `setCloseWindowLevel()`
and the status bar remains hidden even though the side bar is closed.

You can reproduce the issue by dragging the sidebar very shortly (and short distance) and release it straight away. (Menu controller - viewWillAppear is called, but `RightPanState.lastState != .Changed` is true)

Removing the conditions from L465-L464 fixed the issue for me.
I'm not sure if it affects on somewhere else.