### PR TITLE
Add animation to change mainViewController

### DIFF
--- a/Source/SlideMenuController.swift
+++ b/Source/SlideMenuController.swift
@@ -56,6 +56,10 @@ public class SlideMenuController: UIViewController, UIGestureRecognizerDelegate 
         case RightFlickClose
     }
     
+    public enum SlideDirection {
+	case Left
+	case Right
+    }
     
     struct PanInfo {
         var action: SlideAction
@@ -666,6 +670,36 @@ public class SlideMenuController: UIViewController, UIGestureRecognizerDelegate 
             closeRight()
         }
     }
+    
+    public func slideMainViewController(mainViewController: UIViewController, close: Bool, direction: SlideDirection, duration: Double) {
+		
+		var animationWidth : CGFloat
+		
+		if (direction == .Right) {
+			animationWidth = mainViewController.view.frame.size.width
+		}
+		else {
+			animationWidth = -mainViewController.view.frame.size.width
+		}
+		
+		let snapshot:UIView = (UIApplication.sharedApplication().delegate!.window!!.snapshotViewAfterScreenUpdates(true))
+		mainViewController.view.addSubview(snapshot);
+		
+		removeViewController(self.mainViewController)
+		self.mainViewController = mainViewController
+		
+		UIView.animateWithDuration(duration, animations: {() in
+			snapshot.layer.opacity = 0;
+			snapshot.layer.transform = CATransform3DMakeTranslation(animationWidth, 0.0, 0.0)
+			}, completion: nil);
+		
+		setUpViewController(mainContainerView, targetViewController: mainViewController)
+		
+		if (close) {
+			closeLeft()
+			closeRight()
+		}
+	}
     
     public func changeLeftViewWidth(width: CGFloat) {
         

--- a/Source/SlideMenuController.swift
+++ b/Source/SlideMenuController.swift
@@ -57,8 +57,8 @@ public class SlideMenuController: UIViewController, UIGestureRecognizerDelegate 
     }
     
     public enum SlideDirection {
-	case Left
-	case Right
+	case Up
+	case Down
     }
     
     struct PanInfo {
@@ -671,35 +671,34 @@ public class SlideMenuController: UIViewController, UIGestureRecognizerDelegate 
         }
     }
     
-    public func slideMainViewController(mainViewController: UIViewController, close: Bool, direction: SlideDirection, duration: Double) {
-		
-		var animationWidth : CGFloat
-		
-		if (direction == .Right) {
-			animationWidth = mainViewController.view.frame.size.width
-		}
-		else {
-			animationWidth = -mainViewController.view.frame.size.width
-		}
-		
-		let snapshot:UIView = (UIApplication.sharedApplication().delegate!.window!!.snapshotViewAfterScreenUpdates(true))
-		mainViewController.view.addSubview(snapshot);
-		
-		removeViewController(self.mainViewController)
-		self.mainViewController = mainViewController
-		
-		UIView.animateWithDuration(duration, animations: {() in
-			snapshot.layer.opacity = 0;
-			snapshot.layer.transform = CATransform3DMakeTranslation(animationWidth, 0.0, 0.0)
-			}, completion: nil);
-		
-		setUpViewController(mainContainerView, targetViewController: mainViewController)
-		
-		if (close) {
-			closeLeft()
-			closeRight()
-		}
+    public func replaceMainViewController(mainViewController: UIViewController, close: Bool, direction: SlideDirection, duration: Double) {
+	let snapshot:UIView = (UIApplication.sharedApplication().delegate!.window!!.snapshotViewAfterScreenUpdates(true))
+	mainViewController.view.addSubview(snapshot);
+	
+	self.mainViewController = mainViewController
+	
+	let finalFrame = self.mainViewController?.view.frame
+	
+	var offset = UIScreen.mainScreen().bounds.size.height
+	if direction == .Down {
+		offset = -offset
 	}
+	
+	self.mainViewController!.view.frame = CGRectOffset(finalFrame!, 0, offset)
+	
+	UIView.animateWithDuration(duration, delay: 0.0, usingSpringWithDamping: 0.5, initialSpringVelocity: 0.0, options: .CurveLinear, animations: {
+		snapshot.alpha = 0.0
+		self.mainViewController!.view.frame = finalFrame!
+		},
+	completion: nil)
+	
+	setUpViewController(mainContainerView, targetViewController: mainViewController)
+	
+	if (close) {
+		closeLeft()
+		closeRight()
+	}
+    }
     
     public func changeLeftViewWidth(width: CGFloat) {
         


### PR DESCRIPTION
This pull request adds a new method `slideMainViewController`. This allows you to change the `mainViewController` with an animation to either slide to the left or right. 

The method is `slideMainViewController(mainViewController: UIViewController, close: Bool, direction: SlideDirection, duration: Double)`