### PR TITLE
Avoid userInteraction during panGesture

### DIFF
--- a/Source/SlideMenuController.swift
+++ b/Source/SlideMenuController.swift
@@ -213,6 +213,7 @@ public class SlideMenuController: UIViewController, UIGestureRecognizerDelegate 
         self.delegate?.leftWillOpen?()
         
         setOpenWindowLevel()
+        disableContentInteraction()
         // for call viewWillAppear of leftViewController
         leftViewController?.beginAppearanceTransition(isLeftHidden(), animated: true)
         openLeftWithVelocity(0.0)
@@ -228,6 +229,7 @@ public class SlideMenuController: UIViewController, UIGestureRecognizerDelegate 
         self.delegate?.rightWillOpen?()
         
         setOpenWindowLevel()
+        disableContentInteraction()
         rightViewController?.beginAppearanceTransition(isRightHidden(), animated: true)
         openRightWithVelocity(0.0)
         
@@ -368,6 +370,7 @@ public class SlideMenuController: UIViewController, UIGestureRecognizerDelegate 
                 leftViewController?.beginAppearanceTransition(LeftPanState.wasHiddenAtStartOfPan, animated: true)
                 addShadowToView(leftContainerView)
                 setOpenWindowLevel()
+                disableContentInteraction()
             case UIGestureRecognizerState.Changed:
                 if LeftPanState.lastState != .Began && LeftPanState.lastState != .Changed {
                     return
@@ -444,6 +447,7 @@ public class SlideMenuController: UIViewController, UIGestureRecognizerDelegate 
             
             addShadowToView(rightContainerView)
             setOpenWindowLevel()
+            disableContentInteraction()
         case UIGestureRecognizerState.Changed:
             if RightPanState.lastState != .Began && RightPanState.lastState != .Changed {
                 return
@@ -481,7 +485,7 @@ public class SlideMenuController: UIViewController, UIGestureRecognizerDelegate 
         RightPanState.lastState = panGesture.state
     }
     
-    public func openLeftWithVelocity(velocity: CGFloat) {
+    private func openLeftWithVelocity(velocity: CGFloat) {
         let xOrigin: CGFloat = leftContainerView.frame.origin.x
         let finalXOrigin: CGFloat = 0.0
         
@@ -506,14 +510,13 @@ public class SlideMenuController: UIViewController, UIGestureRecognizerDelegate 
             }
             }) { [weak self](Bool) -> Void in
                 if let strongSelf = self {
-                    strongSelf.disableContentInteraction()
                     strongSelf.leftViewController?.endAppearanceTransition()
                     strongSelf.delegate?.leftDidOpen?()
                 }
         }
     }
     
-    public func openRightWithVelocity(velocity: CGFloat) {
+    private func openRightWithVelocity(velocity: CGFloat) {
         let xOrigin: CGFloat = rightContainerView.frame.origin.x
     
         //	CGFloat finalXOrigin = SlideMenuOptions.rightViewOverlapWidth;
@@ -539,7 +542,6 @@ public class SlideMenuController: UIViewController, UIGestureRecognizerDelegate 
             }
             }) { [weak self](Bool) -> Void in
                 if let strongSelf = self {
-                    strongSelf.disableContentInteraction()
                     strongSelf.rightViewController?.endAppearanceTransition()
                     strongSelf.delegate?.rightDidOpen?()
                 }

--- a/Source/SlideMenuController.swift
+++ b/Source/SlideMenuController.swift
@@ -378,10 +378,6 @@ public class SlideMenuController: UIViewController, UIGestureRecognizerDelegate 
                 applyLeftOpacity()
                 applyLeftContentViewScale()
             case UIGestureRecognizerState.Ended, UIGestureRecognizerState.Cancelled:
-                if LeftPanState.lastState != .Changed {
-                    return
-                }
-                
                 let velocity:CGPoint = panGesture.velocityInView(panGesture.view)
                 let panInfo: PanInfo = panLeftResultInfoForVelocity(velocity)
                 
@@ -459,10 +455,6 @@ public class SlideMenuController: UIViewController, UIGestureRecognizerDelegate 
             applyRightContentViewScale()
             
         case UIGestureRecognizerState.Ended, UIGestureRecognizerState.Cancelled:
-            if RightPanState.lastState != .Changed {
-                return
-            }
-            
             let velocity: CGPoint = panGesture.velocityInView(panGesture.view)
             let panInfo: PanInfo = panRightResultInfoForVelocity(velocity)
             


### PR DESCRIPTION
When pan gesture just started, user interaction are not disable and if opacityView still have an opacity < 0.01 (@see : [UIView.hitTest:withEvent](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIView_Class/index.html#//apple_ref/occ/instm/UIView/hitTest:withEvent:)), user can make interaction on mainController.

This can produce bugs like this on sample app (to reproduce : start left pan and simultaneously select a row with a tap in main table view controller) :
 
![img_5851](https://cloud.githubusercontent.com/assets/4833773/16772160/65e05f0e-4853-11e6-859b-b35b3cf4654a.PNG)

I also set openXXXWithVelocity private as call these methods directly doesn't produce a reliable result (windowLevel and beginAppearanceTransition are missing)