### PR TITLE
Adding new SlideMenuOptions bools to allow disabling of pan or tap gestures

### DIFF
--- a/Source/SlideMenuController.swift
+++ b/Source/SlideMenuController.swift
@@ -36,6 +36,8 @@ public struct SlideMenuOptions {
     public static var pointOfNoReturnWidth: CGFloat = 44.0
     public static var simultaneousGestureRecognizers: Bool = true
 	public static var opacityViewBackgroundColor: UIColor = UIColor.blackColor()
+    public static var panGesturesEnabled: Bool = true
+    public static var tapGesturesEnabled: Bool = true
 }
 
 public class SlideMenuController: UIViewController, UIGestureRecognizerDelegate {
@@ -262,16 +264,20 @@ public class SlideMenuController: UIViewController, UIGestureRecognizerDelegate 
     public func addLeftGestures() {
     
         if (leftViewController != nil) {
-            if leftPanGesture == nil {
-                leftPanGesture = UIPanGestureRecognizer(target: self, action: #selector(self.handleLeftPanGesture(_:)))
-                leftPanGesture!.delegate = self
-                view.addGestureRecognizer(leftPanGesture!)
+            if (SlideMenuOptions.panGesturesEnabled) {
+                if leftPanGesture == nil {
+                    leftPanGesture = UIPanGestureRecognizer(target: self, action: #selector(self.handleLeftPanGesture(_:)))
+                    leftPanGesture!.delegate = self
+                    view.addGestureRecognizer(leftPanGesture!)
+                }
             }
             
-            if leftTapGesture == nil {
-                leftTapGesture = UITapGestureRecognizer(target: self, action: #selector(self.toggleLeft))
-                leftTapGesture!.delegate = self
-                view.addGestureRecognizer(leftTapGesture!)
+            if (SlideMenuOptions.tapGesturesEnabled) {
+                if leftTapGesture == nil {
+                    leftTapGesture = UITapGestureRecognizer(target: self, action: #selector(self.toggleLeft))
+                    leftTapGesture!.delegate = self
+                    view.addGestureRecognizer(leftTapGesture!)
+                }
             }
         }
     }
@@ -279,16 +285,20 @@ public class SlideMenuController: UIViewController, UIGestureRecognizerDelegate 
     public func addRightGestures() {
         
         if (rightViewController != nil) {
-            if rightPanGesture == nil {
-                rightPanGesture = UIPanGestureRecognizer(target: self, action: #selector(self.handleRightPanGesture(_:)))
-                rightPanGesture!.delegate = self
-                view.addGestureRecognizer(rightPanGesture!)
+            if (SlideMenuOptions.panGesturesEnabled) {
+                if rightPanGesture == nil {
+                    rightPanGesture = UIPanGestureRecognizer(target: self, action: #selector(self.handleRightPanGesture(_:)))
+                    rightPanGesture!.delegate = self
+                    view.addGestureRecognizer(rightPanGesture!)
+                }
             }
             
-            if rightTapGesture == nil {
-                rightTapGesture = UITapGestureRecognizer(target: self, action: #selector(self.toggleRight))
-                rightTapGesture!.delegate = self
-                view.addGestureRecognizer(rightTapGesture!)
+            if (SlideMenuOptions.tapGesturesEnabled) {
+                if rightTapGesture == nil {
+                    rightTapGesture = UITapGestureRecognizer(target: self, action: #selector(self.toggleRight))
+                    rightTapGesture!.delegate = self
+                    view.addGestureRecognizer(rightTapGesture!)
+                }
             }
         }
     }


### PR DESCRIPTION
In my current project I have many viewControllers where I do not want the left menu accessible, or viewControllers that use a map or other UI that need left/right swiping.  Rather than having to individually remember to removeLeftGestures() in each viewController (and loose the tap to dismiss gesture in the process) – it made far more sense for me to have a boolean in the options to just globally prevent the pan gesture from being init'd.   Net result is that I can rest assured the pan wont cause my users problems, and I still get to keep the tap to dismiss which I very much still wanted.  On the chance that some other developer was interested in disabling the tap gesture (or both), I went ahead and added a boolean for the tap gestures as well.  Options defaults are of course set to enabled/true so no impact to anyone already using this, but the options are now there for those who are interested in them.