### PR TITLE
Carthage fix

### DIFF
--- a/SlideMenuControllerSwift.xcodeproj/project.pbxproj
+++ b/SlideMenuControllerSwift.xcodeproj/project.pbxproj
@@ -628,6 +628,7 @@
 				INFOPLIST_FILE = SlideMenuControllerSwift/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "dekatotoro.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 3.0;


### PR DESCRIPTION
We solve that error

`*\* CLEAN FAILED **

The following build commands failed:
    Check dependencies
(1 failure)
*\* BUILD FAILED **

The following build commands failed:
    Check dependencies
(1 failure)
A shell task (/usr/bin/xcrun xcodebuild -project /Users/XXX/XXX/iOS/Carthage/Checkouts/SlideMenuControllerSwift/SlideMenuControllerSwift.xcodeproj -scheme SlideMenuControllerSwift-iOS -configuration Release -sdk iphoneos ONLY_ACTIVE_ARCH=NO BITCODE_GENERATION_MODE=bitcode CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= CARTHAGE=YES clean build) failed with exit code 65:
*\* CLEAN FAILED **

The following build commands failed:
    Check dependencies
(1 failure)
*\* BUILD FAILED **

The following build commands failed:
    Check dependencies
(1 failure)`
