### PR TITLE
Build error due to double Info.plist

### DIFF
--- a/SlideMenuControllerSwift.podspec
+++ b/SlideMenuControllerSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "SlideMenuControllerSwift"
-  s.version      = "3.0.0"
+  s.version      = "3.0.1"
   s.summary      = "iOS Slide View based on iQON, Feedly, Google+, Ameba iPhone app."
   s.homepage     = "https://github.com/dekatotoro/SlideMenuControllerSwift"
   s.license      = { :type => "MIT", :file => "LICENSE" }
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.platform     = :ios
   s.ios.deployment_target = "8.0"
   s.source       = { :git => "https://github.com/dekatotoro/SlideMenuControllerSwift.git", :tag => s.version }
-  s.source_files  = "Source/*"
+  s.source_files  = "Source/**.swift"
   s.requires_arc = true
 end
 


### PR DESCRIPTION
We use CocoaPods for dependency management and very often get the error "Failed to verify code signature of /path/to/on/physical/device/MyApp.app/Frameworks/SlideMenuControllerSwift.framework/SlideMenuControllerSwift" or "required code signature missing for ..." when deploying the app to a physical device.
According to this (http://stackoverflow.com/questions/40110392/required-code-signature-missing-for-a-library) we are not the only one.
After finding this (https://github.com/vikmeup/SCLAlertView-Swift/issues/114) I assume it has to do with the source_files pattern in your podspec, leading to a duplicate Info.plist. This results in undefined behavior on which Info.plist is included in the final framework bundle. Sometimes the build system selects the wrong one which isn't preprocessed and still contains all the placeholders like ${EXECUTABLE_NAME}.