### PR TITLE
Fix view hierarchy extra call

### DIFF
--- a/Source/SlideMenuController.swift
+++ b/Source/SlideMenuController.swift
@@ -189,7 +189,8 @@ open class SlideMenuController: UIViewController, UIGestureRecognizerDelegate {
 
     override open func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        self.mainViewController?.viewWillAppear(animated)
+        //automatically called 
+        //self.mainViewController?.viewWillAppear(animated)
     }
     
     open override var supportedInterfaceOrientations : UIInterfaceOrientationMask {

--- a/Source/SlideMenuController.swift
+++ b/Source/SlideMenuController.swift
@@ -902,10 +902,13 @@ open class SlideMenuController: UIViewController, UIGestureRecognizerDelegate {
     
     fileprivate func setUpViewController(_ targetView: UIView, targetViewController: UIViewController?) {
         if let viewController = targetViewController {
-            addChildViewController(viewController)
             viewController.view.frame = targetView.bounds
-            targetView.addSubview(viewController.view)
-            viewController.didMove(toParentViewController: self)
+            
+            if (!childViewControllers.contains(viewController)) {
+                addChildViewController(viewController)
+                targetView.addSubview(viewController.view)
+                viewController.didMove(toParentViewController: self)
+            }
         }
     }
     


### PR DESCRIPTION
This fix avoid duplicate events such as viewWillAppear and viewDidAppear to be call on children viewControllers.