### PR TITLE
Changed podspec to load only swift sources

### DIFF
--- a/SlideMenuControllerSwift.podspec
+++ b/SlideMenuControllerSwift.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.platform     = :ios
   s.ios.deployment_target = "8.0"
   s.source       = { :git => "https://github.com/dekatotoro/SlideMenuControllerSwift.git", :tag => s.version }
-  s.source_files  = "Source/*"
+  s.source_files  = "Source/*.swift"
   s.requires_arc = true
 end
 


### PR DESCRIPTION
cocoapods creates its own Info.plist and sometimes two plists produce error during build:
```
“Info.plist” couldn’t be removed.
```
or during installation
```
Failed to verify code signature of SlideMenuControllerSwift.framework
```