### PR TITLE
Fix for issue #244 in the swift 2.3 branch

### DIFF
--- a/SlideMenuControllerSwift.podspec
+++ b/SlideMenuControllerSwift.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.platform     = :ios
   s.ios.deployment_target = "8.0"
   s.source       = { :git => "https://github.com/dekatotoro/SlideMenuControllerSwift.git", :tag => s.version }
-  s.source_files  = "Source/*"
+  s.source_files  = "Source/*.swift"
   s.requires_arc = true
 end
 


### PR DESCRIPTION
Swift 2.3 branch fix for issue #244: Build error due to double Info.plist

This issue is already fixed in master, but not in other branches.