### PR TITLE
Remove harmful second creation of mainContainerView.

### DIFF
--- a/Source/SlideMenuController.swift
+++ b/Source/SlideMenuController.swift
@@ -117,7 +117,7 @@ open class SlideMenuController: UIViewController, UIGestureRecognizerDelegate {
     deinit { }
     
     open func initView() {
-        mainContainerView = UIView(frame: view.bounds)
+        mainContainerView.frame = view.bounds
         mainContainerView.backgroundColor = UIColor.clear
         mainContainerView.autoresizingMask = [.flexibleHeight, .flexibleWidth]
         view.insertSubview(mainContainerView, at: 0)


### PR DESCRIPTION
mainContainerView is created 2 times now. One time in property and one time in initView function. The second is redundant and lead to problem, when my view is added to first created mainContainerView, then mainContainerView is replaced by second created and my view is not showing. So, second creation of mainContainerView is removed.