### PR TITLE
Fix delegate methods not called when pan cancelled

### DIFF
--- a/Source/SlideMenuController.swift
+++ b/Source/SlideMenuController.swift
@@ -421,6 +421,7 @@ open class SlideMenuController: UIViewController, UIGestureRecognizerDelegate {
                     closeLeftWithVelocity(panInfo.velocity)
                     setCloseWindowLevel()
                     
+                    self.delegate?.leftWillClose?()
                     track(.leftFlickClose)
 
                 }
@@ -503,6 +504,7 @@ open class SlideMenuController: UIViewController, UIGestureRecognizerDelegate {
                 closeRightWithVelocity(panInfo.velocity)
                 setCloseWindowLevel()
                 
+                self.delegate?.rightWillClose?()
                 track(.rightFlickClose)
             }
         case UIGestureRecognizerState.failed, UIGestureRecognizerState.possible:


### PR DESCRIPTION
I noticed that leftWillClose/rightWillClose delegate methods are not called when the pan is cancelled, while in reality they should. These changes address this issue.